### PR TITLE
Listing Specific MealFoods Endpoint

### DIFF
--- a/routes/api/v1/meals.js
+++ b/routes/api/v1/meals.js
@@ -9,12 +9,34 @@ var pry = require('pryjs');
 router.get('/', function (req, res) {
   Meal.findAll({
     attributes: ['id', 'name'],
-    include: [{model:Food, attributes: ['id', 'name', 'calories'], through: { attributes: []}}],
-    exclude: [{model:Food.MealFood}]
+    include: [{model:Food, attributes: ['id', 'name', 'calories'], through: { attributes: []}}]
   })
-  .then(foods => {
+  .then(meals => {
     res.setHeader('Content-Type', 'application/json')
-    res.status(200).send(foods)
+    res.status(200).send(meals)
+  })
+  .catch(error => {
+    res.setHeader('Content-Type', 'application/json')
+    res.status(404).send({error})
+  })
+})
+
+router.get('/:id/foods', function (req, res) {
+  Meal.findOne({
+    where: {
+      id: req.params.id
+    },
+    attributes: ['id', 'name'],
+    include: [{model:Food, attributes: ['id', 'name', 'calories'], through: { attributes: []}}]
+  })
+  .then(meal => {
+    if (meal) {
+      res.setHeader('Content-Type', 'application/json')
+      res.status(200).send(meal)
+    } else {
+      res.setHeader('Content-Type', 'application/json')
+      res.status(404).send(JSON.stringify({"error": "Meal not found!!"}))
+    }
   })
   .catch(error => {
     res.setHeader('Content-Type', 'application/json')
@@ -24,9 +46,3 @@ router.get('/', function (req, res) {
 
 
 module.exports = router;
-
-// Helper Methods
-
-// function _responseFormatter(foods) {
-//   delete foods
-// }

--- a/spec/meals.spec.js
+++ b/spec/meals.spec.js
@@ -25,4 +25,25 @@ describe('Meals API', () => {
       })
     })
   })
+
+  describe('Test GET /api/v1/meals/1/foods', () => {
+    test('should return a 200 status and meal and it\'s foods', () => {
+      return request(app).get('/api/v1/meals/1/foods').then(response => {
+        expect(response.status).toBe(200)
+        expect(response.body).toBeInstanceOf(Object)
+        expect(response.body.name).toBe("Breakfast")
+        expect(response.body.id).toBe(1)
+        expect(response.body.Food).toBeInstanceOf(Array)
+        expect(Object.keys(response.body.Food[0])).toContain('id')
+        expect(Object.keys(response.body.Food[0])).toContain('name')
+        expect(Object.keys(response.body.Food[0])).toContain('calories')
+      })
+    })
+    test('should return a 404 and error message if meal is not found', () => {
+      return request(app).get('/api/v1/meals/16/foods').then(response => {
+        expect(response.status).toBe(404)
+        expect(response.body.error).toBe("Meal not found!!")
+      })
+    })
+  })
 });


### PR DESCRIPTION
Resolves issue #9 
Create tests, Create our meal foods show endpoint
Co-authored-by: Scott Thomas <31359242+smthom05@users.noreply.github.com>

- [x] Tested
- [x] Route is `GET /api/v1/meals/:meal_id/foods`
- [x] Returns all the foods associated with the meal with an id specified by :meal_id like below
```
{
    "id": 1,
    "name": "Breakfast",
    "foods": [
        {
            "id": 1,
            "name": "Banana",
            "calories": 150
        },
        {
            "id": 6,
            "name": "Yogurt",
            "calories": 550
        },
        {
            "id": 12,
            "name": "Apple",
            "calories": 220
        }
    ]
}
```
- [x] Returns a `404 status code `if the meal is not found

