### PR TITLE
Deleting a MealFoods Association Endpoint

### DIFF
--- a/routes/api/v1/meals.js
+++ b/routes/api/v1/meals.js
@@ -74,5 +74,26 @@ router.post('/:meal_id/foods/:food_id', function (req, res) {
     res.status(404).send(JSON.stringify({"error": "MealFood Not Created"}))
   })
 })
-
+// Delete  MealFood Assocation Endpoint
+router.delete('/:meal_id/foods/:food_id', function (req, res) {
+  MealFood.destroy({
+    where: {
+      MealId: req.params.meal_id,
+      FoodId: req.params.food_id
+    }
+  })
+  .then(mealFood => {
+    if (mealFood) {
+      res.setHeader('Content-Type', 'application/json')
+      res.status(204).send(JSON.stringify({"success": `Successfully Deleted MealFood!!`}))
+    } else {
+      res.setHeader('Content-Type', 'application/json')
+      res.status(404).send(JSON.stringify({"error": `MealFood not found!!`}))
+    }
+  })
+  .catch(error => {
+    res.setHeader('Content-Type', 'application/json')
+    res.status(404).send(JSON.stringify({"error": "MealFood Not Created"}))
+  })
+})
 module.exports = router;

--- a/spec/meals.spec.js
+++ b/spec/meals.spec.js
@@ -58,4 +58,18 @@ describe('Meals API', () => {
       })
     })
   })
+  //Delete
+  describe('Test DELETE /api/v1/meals/1/foods/7', () => {
+    test('should return a 204 status', () => {
+      return request(app).delete('/api/v1/meals/1/foods/7').then(response => {
+        expect(response.status).toBe(204)
+      })
+    })
+
+    test('should return a 404 status for non existant mealfood', () => {
+      return request(app).delete('/api/v1/meals/11/foods/71').then(response => {
+        expect(response.status).toBe(404)
+      })
+    })
+  })
 });


### PR DESCRIPTION
Resolves issue #11 
Add tests, create mealfood deletion endpoint
Summary: Removes the food with :id from the meal with :meal_id

- [x] Tested
- [x] Route is `DELETE /api/v1/meals/:meal_id/foods/:id`
- [x] If successful, this deletes the existing record in the MealFoods table that creates the relationship between this food and meal. Returns `204 status code`.
- [x] If the meal/food cannot be found, a `404 status code` will be returned.

Co-authored-by: Scott Thomas <31359242+smthom05@users.noreply.github.com>
